### PR TITLE
DEVOPS-3045 Add helm-v3 version, update vault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM alpine:3.9.3
 ENV HELM_VERSION v2.16.0
 ENV HELM_DIFF_VERSION v2.11.0+5
 ENV HELM_SECRET_VERSION v1.3.1
+ENV HELM_V3_VERSION v3.0.2
+ENV HELM_V3_SHA256 c6b7aa7e4ffc66e8abb4be328f71d48c643cb8f398d95c74d075cfb348710e1d
 ENV HELMFILE_VERSION 0.90.8
 ENV AWS_IAM_AUTH_VERSION 0.4.0
-ENV VAULT_VERSION 1.0.1
+ENV VAULT_VERSION 1.3.1
 ENV AWS_CLI_VERSION 1.16.276
 
 RUN apk --no-cache add curl bash make openssh jq ca-certificates git gettext groff less \
@@ -14,6 +16,8 @@ RUN apk --no-cache add curl bash make openssh jq ca-certificates git gettext gro
     && apk add git-crypt-0.6.0-r1.apk \
     && rm git-crypt-0.6.0-r1.apk
 
+# TODO: kubectl officially support k8s +1 and -2 minor versions
+# for now stable k8s is 1.17.1, for example on k8s-core we have k8s 1.13
 RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
@@ -34,6 +38,12 @@ RUN mkdir -p "$(helm home)/plugins" \
 RUN wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
  && unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip \
  && rm vault_${VAULT_VERSION}_linux_amd64.zip
+
+RUN curl -sLo /tmp/helm-v3.tar.gz https://get.helm.sh/helm-${HELM_V3_VERSION}-linux-amd64.tar.gz \
+ && echo "${HELM_V3_SHA256}  /tmp/helm-v3.tar.gz" | sha256sum -c - \
+ && tar -zxf /tmp/helm-v3.tar.gz -C /tmp/ \
+ && cp /tmp/linux-amd64/helm /usr/local/bin/helm3 \
+ && rm -rf /tmp/linux-amd64/ /tmp/helm-v3.tar.gz
 
 RUN curl -L -o aws-iam-authenticator_${AWS_IAM_AUTH_VERSION}_linux_amd64 https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTH_VERSION}/aws-iam-authenticator_${AWS_IAM_AUTH_VERSION}_linux_amd64 \
  && curl -L -o authenticator_checksums.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTH_VERSION}/authenticator_${AWS_IAM_AUTH_VERSION}_checksums.txt \


### PR DESCRIPTION
We need to keep two versions of the helm, while we did not completely migrate
tp v3. For using a new binary with helmfiles use `-b helm3` as an argument.

Also, bump vault version to current